### PR TITLE
Adding the RTC module

### DIFF
--- a/u2f_arduino_key/src/dataConverter.cpp
+++ b/u2f_arduino_key/src/dataConverter.cpp
@@ -1,8 +1,9 @@
 /*
  * Created by Jakub SQTX Sitarczyk on 28/10/2023.
-*/
+ * */
 
 #include "dataConverter.h"
+
 
 String Converter::convBase32ToTxt(String* in) {
   String out {};

--- a/u2f_arduino_key/src/dataConverter.h
+++ b/u2f_arduino_key/src/dataConverter.h
@@ -1,6 +1,6 @@
 /*
  * Created by Jakub SQTX Sitarczyk on 28/10/2023.
-*/
+ * */
 
 #ifndef U2F_ARDUINO_KEY_DATACONVERTER_H
 #define U2F_ARDUINO_KEY_DATACONVERTER_H

--- a/u2f_arduino_key/u2f_arduino_key.ino
+++ b/u2f_arduino_key/u2f_arduino_key.ino
@@ -14,6 +14,7 @@
 // ******************************************************************
 // Configuration:
 // constexpr uint8_t KEY_SIZE = 30;   // Moved to dataConverter.h
+  constexpr int8_t RTC_OFFSET = 5;   // Time difference between the real time time and the RTC module [in seconds]: (Real_time - RTC)
 
 
 // ******************************************************************
@@ -46,8 +47,8 @@ void loop() {
   // RTC:
   DateTime now {myRTC.now()};   // Get current time from RTC module
   long UnixTimeStep {now.unixtime()};
-  //   UTC = CET(summer_time) - 2h
-  long UTC {UnixTimeStep - (2*60*60)};
+  //   UTC = CET(summer_time) - 2h + RTC_OFFSET
+  long UTC {UnixTimeStep - (2*60*60) + RTC_OFFSET};
 
   Serial.print("TIME: ");
   Serial.println(UTC);
@@ -61,8 +62,10 @@ void loop() {
     Serial.print("Token: ");
     Serial.println(code);
   }
-
-
   Serial.println("===========================");
-  delay(30000);  // TODO: Hard-code 30 seconds
+
+
+  // Dynamic refresh (Always every 00' and 30' seconds)
+  uint16_t restTime {(30 - (UTC % 30)) * 1000};
+  delay(restTime);
 }

--- a/u2f_arduino_key/u2f_arduino_key.ino
+++ b/u2f_arduino_key/u2f_arduino_key.ino
@@ -1,6 +1,6 @@
 /*
  * Created by Jakub SQTX Sitarczyk on 21/10/2023.
-*/
+ * */
 
 // Arduino lib:
 #include <Wire.h>
@@ -13,8 +13,17 @@
 
 // ******************************************************************
 // Configuration:
-// constexpr uint8_t KEY_SIZE = 30;   // Moved to dataConverter.h
-  constexpr int8_t RTC_OFFSET = 5;   // Time difference between the real time time and the RTC module [in seconds]: (Real_time - RTC)
+// constexpr uint8_t KEY_SIZE {30};       //TODO:  Moved to dataConverter.h
+
+  /* The hour difference between the time zone set to RTC and the UTC time zone [in hours]:
+   * CET(summer_time) - UTC = 2 [h]
+   * */
+  constexpr int8_t TIME_ZONE_OFFSET {2};
+  /* Time difference between the RTC module time and the real time [in seconds]:
+   * 1698601110 - 1698601115 = -5 [s]
+   * */
+  constexpr int8_t RTC_OFFSET {-5};       //
+                                          //
 
 
 // ******************************************************************
@@ -24,6 +33,10 @@ String keysDB[2] {"JV4VG2LNOBWGKU3FMNZGK5CUPB2EWZLZ",   // "MySimpleSecretTxtKey
 
 
 // ******************************************************************
+/* Using the DS3231 RTC module requires its prior configuration and setting of the current time
+ * from which the RTC will constantly count up. For this, you can use the DS3231.h library and
+ * the DS3231_set example.
+ * */
 RTClib myRTC;
 
 
@@ -44,14 +57,14 @@ void loop() {
   char code[7];
 
 
-  // RTC:
-  DateTime now {myRTC.now()};   // Get current time from RTC module
-  long UnixTimeStep {now.unixtime()};
-  //   UTC = CET(summer_time) - 2h + RTC_OFFSET
-  long UTC {UnixTimeStep - (2*60*60) + RTC_OFFSET};
+  // Get currently time from RTC module:
+  DateTime now {myRTC.now()};           // Get current time
+  long UnixTimeStep {now.unixtime()};   // Replacement in Unix TimeStamp
+  //   UTC = (local_time - TIME_ZONE_OFFSET - RTC_OFFSET)
+  long UTC {UnixTimeStep - (TIME_ZONE_OFFSET*60*60) - RTC_OFFSET};
 
-  Serial.print("TIME: ");
-  Serial.println(UTC);
+//  Serial.print("TIME: ");
+//  Serial.println(UTC);
 
 
   char* newCode {totp.getCode(UTC)};  // Generate new token
@@ -62,7 +75,7 @@ void loop() {
     Serial.print("Token: ");
     Serial.println(code);
   }
-  Serial.println("===========================");
+  Serial.println("==============");
 
 
   // Dynamic refresh (Always every 00' and 30' seconds)


### PR DESCRIPTION
All changes concern the **RTC DS3231 module** added to the board.

### List of changes:
- Removing the `swRTC.h` library and adding the `Wire.h` and `DS3231.h` libraries,
- **Changing the RTC mechanism**,
From now the current time is got automatically from the RTC module — manual typing isn't required anymore,
- Added configuration parameters: 
  - `TIME_ZONE_OFFSET` 
  - `RTC_OFFSET`
- Removal of the time display function,
- Adding dynamic refresh every 0' and 30' seconds of every minute,
- Adding documentation comments.

Close #11