### PR TITLE
Operation control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ fabric.properties
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
+
+
+/priv

--- a/u2f_arduino_key/src/dataController.cpp
+++ b/u2f_arduino_key/src/dataController.cpp
@@ -5,14 +5,15 @@
 #include "dataController.h"
 
 static void DataController::writeDataToEEPROM(String *keys, const int numberOfKeys, const int MAX_SIZE) {
-  int addresIndex{0};
+  int addresIndex {0};
   writeIntToEEPROM(&addresIndex, numberOfKeys);
   writeIntToEEPROM(&addresIndex, MAX_SIZE);
 
-  if (numberOfKeys == 0) { ;
+  if(numberOfKeys == 0) {
+    ;
   } else {
     Serial.println("Saving in processing");
-    for (int i = 0; i < (numberOfKeys * 2); i++) {
+    for(int i = 0; i < (numberOfKeys*2); i++) {
       uint8_t txtSize = keys[i].length() + 1;
       writeIntToEEPROM(&addresIndex, txtSize);
       writeStringToEEPROM(&addresIndex, keys[i]);
@@ -21,17 +22,17 @@ static void DataController::writeDataToEEPROM(String *keys, const int numberOfKe
   }
 }
 
-static String *DataController::readDataFromEEPROM(int *numberOfKeys) {
-  int addresIndex{0};
+static String* DataController::readDataFromEEPROM(int *numberOfKeys) {
+  int addresIndex {0};
 
   uint8_t keysNumber = readIntFromEEPROM(&addresIndex);
   (*numberOfKeys) = keysNumber;
 //  uint8_t maxEEPROMSize = readIntFromEEPROM(addresIndex++);
   addresIndex++;
 
-  static String *keys = new String[keysNumber * 2];
+  static String *keys = new String[keysNumber*2];
 
-  for (int i = 0; i < keysNumber * 2; i++) {
+  for(int i = 0; i < keysNumber*2; i++) {
     uint8_t txtSize = readIntFromEEPROM(&addresIndex);
     keys[i] = readStringFromEEPROM(&addresIndex, txtSize);
 

--- a/u2f_arduino_key/src/dataController.cpp
+++ b/u2f_arduino_key/src/dataController.cpp
@@ -14,22 +14,22 @@ static void DataController::writeDataToEEPROM(String *keys, const int numberOfKe
   if(numberOfKeys == 0) {
     ;
   } else {
-    Serial.println("DEBUG: Saving is in processing");
+//    Serial.println("DEBUG: Saving is in processing");
     for(int i = 0; i < (numberOfKeys*2); i++) {
       uint8_t txtSize = keys[i].length() + 1;
       writeIntToEEPROM(&addresIndex, txtSize);
       writeStringToEEPROM(&addresIndex, keys[i]);
     }
   }
-  Serial.println("DEBUG: Saving complited!");
+//  Serial.println("DEBUG: Saving complited!");
 }
 
 static String* DataController::readDataFromEEPROM(int *numberOfKeys) {
   int addresIndex {0};
-  Serial.println("DEBUG: Reading is in processing");
+//  Serial.println("DEBUG: Reading is in processing");
 
   if(prefixExist(&addresIndex)) {
-    Serial.println("DEBUG: Prefix is correct");
+//    Serial.println("DEBUG: Prefix is correct");
 
     uint8_t keysNumber = readIntFromEEPROM(&addresIndex);
     (*numberOfKeys) = keysNumber;
@@ -43,7 +43,7 @@ static String* DataController::readDataFromEEPROM(int *numberOfKeys) {
       keys[i] = readStringFromEEPROM(&addresIndex, txtSize);
     }
 
-    Serial.println("DEBUG: Reading complited!");
+//    Serial.println("DEBUG: Reading complited!");
     return keys;
   }else {
     Serial.println("FATAL ERROR: EEPROM memory is not preper to colaborate with \"U2F_arduino_key\" soft!");
@@ -78,7 +78,7 @@ static String* DataController::readDataFromEEPROM(int *numberOfKeys) {
     }while(!decisionMade);
 
     static String *keys = new String[0];
-    Serial.println("DEBUG: Reading complited!");
+//    Serial.println("DEBUG: Reading complited!");
     return keys;    // Return empty array
   }
 }
@@ -90,7 +90,7 @@ static void DataController::addPrefixToEEPROM(int *addrOffset){
 }
 
 static bool DataController::prefixExist(int *addrOffset){
-  Serial.println("DEBUG: Prefix is checking");
+//  Serial.println("DEBUG: Prefix is checking");
   const uint8_t prefixSize = EEPROM_PREFIX.length();
   String currentPrefix = readStringFromEEPROM(addrOffset, prefixSize);
 

--- a/u2f_arduino_key/src/dataController.cpp
+++ b/u2f_arduino_key/src/dataController.cpp
@@ -4,7 +4,7 @@
 
 #include "dataController.h"
 
-static void DataController::writeDataToEEPROM(String *keys, const int numberOfKeys, const int MAX_SIZE = MAX_EEPROM_CAPACITY) {
+static void DataController::writeDataToEEPROM(String *keys, const int numberOfKeys, const int MAX_SIZE) {
   int addresIndex {0};
 
   addPrefixToEEPROM(&addresIndex);

--- a/u2f_arduino_key/src/dataController.cpp
+++ b/u2f_arduino_key/src/dataController.cpp
@@ -4,47 +4,114 @@
 
 #include "dataController.h"
 
-static void DataController::writeDataToEEPROM(String *keys, const int numberOfKeys, const int MAX_SIZE) {
+static void DataController::writeDataToEEPROM(String *keys, const int numberOfKeys, const int MAX_SIZE = MAX_EEPROM_CAPACITY) {
   int addresIndex {0};
+
+  addPrefixToEEPROM(&addresIndex);
   writeIntToEEPROM(&addresIndex, numberOfKeys);
   writeIntToEEPROM(&addresIndex, MAX_SIZE);
 
   if(numberOfKeys == 0) {
     ;
   } else {
-    Serial.println("Saving in processing");
+    Serial.println("DEBUG: Saving is in processing");
     for(int i = 0; i < (numberOfKeys*2); i++) {
       uint8_t txtSize = keys[i].length() + 1;
       writeIntToEEPROM(&addresIndex, txtSize);
       writeStringToEEPROM(&addresIndex, keys[i]);
     }
-    Serial.println("Save Complited!");
   }
+  Serial.println("DEBUG: Saving complited!");
 }
 
 static String* DataController::readDataFromEEPROM(int *numberOfKeys) {
   int addresIndex {0};
+  Serial.println("DEBUG: Reading is in processing");
 
-  uint8_t keysNumber = readIntFromEEPROM(&addresIndex);
-  (*numberOfKeys) = keysNumber;
-//  uint8_t maxEEPROMSize = readIntFromEEPROM(addresIndex++);
-  addresIndex++;
+  if(prefixExist(&addresIndex)) {
+    Serial.println("DEBUG: Prefix is correct");
 
-  static String *keys = new String[keysNumber*2];
+    uint8_t keysNumber = readIntFromEEPROM(&addresIndex);
+    (*numberOfKeys) = keysNumber;
+    uint8_t maxEEPROMSize = readIntFromEEPROM(addresIndex++);
+    addresIndex++;
 
-  for(int i = 0; i < keysNumber*2; i++) {
-    uint8_t txtSize = readIntFromEEPROM(&addresIndex);
-    keys[i] = readStringFromEEPROM(&addresIndex, txtSize);
+    static String *keys = new String[keysNumber*2];
 
-    Serial.println(keys[0]);
-    Serial.println(keys[1]);
+    for(int i = 0; i < keysNumber*2; i++) {
+      uint8_t txtSize = readIntFromEEPROM(&addresIndex);
+      keys[i] = readStringFromEEPROM(&addresIndex, txtSize);
+    }
+
+    Serial.println("DEBUG: Reading complited!");
+    return keys;
+  }else {
+    Serial.println("FATAL ERROR: EEPROM memory is not preper to colaborate with \"U2F_arduino_key\" soft!");
+    Serial.println("Do you want to preper EEPROM memory to colaborate with this soft? (Y/n)");
+    Serial.println("WARNING: Data which are in EEPROM memory currently could be overwriet!");
+
+    bool decisionMade {false};
+    do{
+      char c {'n'};
+
+      Serial.print("Do you agree: ");
+      serialFlush();
+      while(Serial.available() == 0) {}
+      delay(2);
+      if(Serial.available() > 0) {
+        c = Serial.read();
+      }
+      Serial.println("");
+
+
+      if(c == 'Y') {
+        writeDataToEEPROM(nullptr, 0);
+        decisionMade = {true};
+      }else if(c == 'n') {
+        Serial.println("The app gets frozen");
+        while(true) {};                           // NOTE: Infinited loop!
+        decisionMade = {true};
+      }else {
+        Serial.println("Wrong character! Try again.");
+        decisionMade = {false};
+      }
+    }while(!decisionMade);
+
+    static String *keys = new String[0];
+    Serial.println("DEBUG: Reading complited!");
+    return keys;    // Return empty array
   }
-
-  return keys;
 }
 
 
 //Priv --------------------------------------------------------------------------------
+static void DataController::addPrefixToEEPROM(int *addrOffset){
+  writeStringToEEPROM(addrOffset, EEPROM_PREFIX, false);
+}
+
+static bool DataController::prefixExist(int *addrOffset){
+  Serial.println("DEBUG: Prefix is checking");
+  const uint8_t prefixSize = EEPROM_PREFIX.length();
+  String currentPrefix = readStringFromEEPROM(addrOffset, prefixSize);
+
+  char *currentPrefixArr = new char[prefixSize+1];
+  char *goodPrefixArr = new char[prefixSize+1];
+  currentPrefix.toCharArray(currentPrefixArr, prefixSize+1);
+  EEPROM_PREFIX.toCharArray(goodPrefixArr, prefixSize+1);
+
+  if(strcmp(currentPrefixArr, goodPrefixArr) == 0) {
+    delete[] currentPrefixArr;
+    delete[] goodPrefixArr;
+    return true;
+  }
+  else {
+    delete[] currentPrefixArr;
+    delete[] goodPrefixArr;
+    return false;
+  }
+}
+
+
 static void DataController::writeIntToEEPROM(int *addrOffset, const int number) {
   EEPROM.write(*addrOffset, number);
   (*addrOffset)++;
@@ -57,7 +124,7 @@ static int DataController::readIntFromEEPROM(int *addrOffset) {
 }
 
 
-static void DataController::writeStringToEEPROM(int *addrOffset, const String &txt) {
+static void DataController::writeStringToEEPROM(int *addrOffset, const String &txt, bool nullChar) {
   uint8_t size = txt.length();
 
   for (int i = 0; i < size; i++) {
@@ -65,20 +132,34 @@ static void DataController::writeStringToEEPROM(int *addrOffset, const String &t
   }
   (*addrOffset) += size;
 
-  EEPROM.write((*addrOffset), '\0');
-  (*addrOffset)++;
+  if(nullChar){
+    EEPROM.write((*addrOffset), '\0');
+    (*addrOffset)++;
+  }
 }
 
-static String DataController::readStringFromEEPROM(int *addrOffset, int size) {
+static String DataController::readStringFromEEPROM(int *addrOffset, int size, bool nullChar) {
 //  char data[size + 1];
-  char data[size];
+  char *data = new char[size];
 
   for (int i = 0; i < size; i++) {
     data[i] = EEPROM.read((*addrOffset) + i);
   }
-
-//  data[size] = '\0';
-
   (*addrOffset) += size;
-  return String(data);
+
+  if(nullChar) {
+    data[size] = '\0';
+    (*addrOffset)++;
+  }
+
+  String txt = data;
+  delete[] data;
+  return txt;
+}
+
+
+static void DataController::serialFlush(){
+  while(Serial.available() > 0) {
+    char t = Serial.read();
+  }
 }

--- a/u2f_arduino_key/src/dataController.h
+++ b/u2f_arduino_key/src/dataController.h
@@ -11,21 +11,36 @@
 
 class DataController {
 public:
-  static void writeDataToEEPROM(String*, int, int);
-  static String* readDataFromEEPROM(int*);
+  /*! The main function that saves data on the EEPROM memory. The following are transferred to memory:
+   * prefix - allowing you to check whether the EEPROM is already adapted to work with the application,
+   * numberOfKeys - number of all saved keys,
+   * MAX_SIZE - maximum number of keys that can be saved in EEPROM,
+   * keys - an array of keys with their names.
+   * */
+  static void writeDataToEEPROM(String *keys, const int numberOfKeys, const int MAX_SIZE = MAX_EEPROM_CAPACITY);
+
+  /*! A function that checks whether the memory is suitable for the application.
+   * If so, it downloads all the keys with their names and assigns them to RAM.
+   * If not, it allows you to initialize new memory or freezes the application completely.
+   * As an argument, we pass a reference to the container storing the total number of all saved keys.
+   * */
+  static String *readDataFromEEPROM(int *numberOfKeys);
 
 private:
-  static constexpr int MAX_EEPROM_CAPACITY {30};
-  static inline String EEPROM_PREFIX {"sqx"};
+  static constexpr int MAX_EEPROM_CAPACITY{30};
+  static inline String EEPROM_PREFIX{"sqx"};
 
-  static void addPrefixToEEPROM(int *addrOffset);
-  static bool prefixExist(int *addrOffset);
+  static void addPrefixToEEPROM(int *);
 
-  static void writeIntToEEPROM(int*, const int);
-  static int readIntFromEEPROM(int*);
+  static bool prefixExist(int *);
 
-  static void writeStringToEEPROM(int*, const String&, bool nullChar = true);
-  static String readStringFromEEPROM(int*, int, bool nullChar = false);
+  static void writeIntToEEPROM(int *, const int);
+
+  static int readIntFromEEPROM(int *);
+
+  static void writeStringToEEPROM(int *, const String &, bool nullChar = true);
+
+  static String readStringFromEEPROM(int *, int, bool nullChar = false);
 
   static void serialFlush();
 };

--- a/u2f_arduino_key/src/dataController.h
+++ b/u2f_arduino_key/src/dataController.h
@@ -11,18 +11,15 @@
 
 class DataController {
 public:
-  static void writeDataToEEPROM(String *, int, int);
-
-  static String *readDataFromEEPROM(int *);
+  static void writeDataToEEPROM(String*, int, int);
+  static String* readDataFromEEPROM(int*);
 
 private:
-  static void writeIntToEEPROM(int *, const int);
+  static void writeIntToEEPROM(int*, const int);
+  static int readIntFromEEPROM(int*);
 
-  static int readIntFromEEPROM(int *);
-
-  static void writeStringToEEPROM(int *, const String &);
-
-  static String readStringFromEEPROM(int *, int);
+  static void writeStringToEEPROM(int*, const String&);
+  static String readStringFromEEPROM(int*, int);
 };
 
 

--- a/u2f_arduino_key/src/dataController.h
+++ b/u2f_arduino_key/src/dataController.h
@@ -15,11 +15,19 @@ public:
   static String* readDataFromEEPROM(int*);
 
 private:
+  static constexpr int MAX_EEPROM_CAPACITY {30};
+  static inline String EEPROM_PREFIX {"sqx"};
+
+  static void addPrefixToEEPROM(int *addrOffset);
+  static bool prefixExist(int *addrOffset);
+
   static void writeIntToEEPROM(int*, const int);
   static int readIntFromEEPROM(int*);
 
-  static void writeStringToEEPROM(int*, const String&);
-  static String readStringFromEEPROM(int*, int);
+  static void writeStringToEEPROM(int*, const String&, bool nullChar = true);
+  static String readStringFromEEPROM(int*, int, bool nullChar = false);
+
+  static void serialFlush();
 };
 
 

--- a/u2f_arduino_key/src/dataConverter.h
+++ b/u2f_arduino_key/src/dataConverter.h
@@ -9,16 +9,16 @@
 #include <Arduino.h>
 #include "Base32-Decode.h"
 
-// Constant maximum hard-code key size
+//! Constant maximum hard-code key size
 constexpr uint8_t KEY_SIZE = 30;
 
 class Converter {
 public:
-  /* Function that converts a String variable in Base32 format
+  /*! Function that converts a String variable in Base32 format
    * into a string variable in text format.
    * */
   static String convBase32ToTxt(String*);
-  /* Function that converts a String variable in text format
+  /*! Function that converts a String variable in text format
    * into an array of bytes in decimal format.
    * */
   static uint8_t* convStrToNumArr(String*);

--- a/u2f_arduino_key/u2f_arduino_key.ino
+++ b/u2f_arduino_key/u2f_arduino_key.ino
@@ -15,32 +15,14 @@
 
 // ******************************************************************
 // Configuration:
-<<<<<<< HEAD
-//TODO: Add description
-//constexpr int8_t CONTROL_BTN_PIN {7};
-//TODO: Add description
-constexpr int MAX_EEPROM_CAPACITY {30};
-/* The hour difference between the time zone set to RTC and the UTC time zone [in hours]:
+/*! The hour difference between the time zone set to RTC and the UTC time zone [in hours]:
  * CET(summer_time) - UTC = 2 [h]
  * */
 constexpr int8_t TIME_ZONE_OFFSET {2};
-/* Time difference between the RTC module time and the real time [in seconds]:
+/*! Time difference between the RTC module time and the real time [in seconds]:
  * 1698601110 - 1698601115 = -5 [s]
  * */
 constexpr int8_t RTC_OFFSET {-5};
-=======
-// constexpr uint8_t KEY_SIZE {30};       //TODO:  Moved to dataConverter.h
-
-  /* The hour difference between the time zone set to RTC and the UTC time zone [in hours]:
-   * CET(summer_time) - UTC = 2 [h]
-   * */
-  constexpr int8_t TIME_ZONE_OFFSET {2};
-  /* Time difference between the RTC module time and the real time [in seconds]:
-   * 1698601110 - 1698601115 = -5 [s]
-   * */
-  constexpr int8_t RTC_OFFSET {-5};
-  constexpr int MAX_EEPROM_CAPACITY {30};
->>>>>>> parent of 42dccc5 (Autoformat and add TODO notes about delete array and write data to EEPROM)
 
 
 // ******************************************************************
@@ -49,43 +31,38 @@ String keysDB[4] {"github", "JV4VG2LNOBWGKU3FMNZGK5CUPB2EWZLZ",   // "MySimpleSe
                   "text", "IFBEGRBRGIZQ===="};                    // "ABCD123"
 
 
-int numberOfKeys {};
+int numberOfKeys {0};
 String *keysDatabase {};
 
 
 // ******************************************************************
-/* Using the DS3231 RTC module requires its prior configuration and setting of the current time
+/*! Using the DS3231 RTC module requires its prior configuration and setting of the current time
  * from which the RTC will constantly count up. For this, you can use the DS3231.h library and
  * the DS3231_set example.
  * */
 RTClib myRTC;
 
-enum class OPTIONS {POWEROFF = 0,
-                    GENERATE,
-                    ADDNEW};
 
-void generateToken();
-void addNewKey();
-
+void serialFlush();
 
 void setup() {
   Serial.begin(9600);
+  serialFlush();        // Clean flush memory
   Wire.begin();
 
-  // EEPROM.write(0, 0);
-  // DataController::writeDataToEEPROM(keysDB, 2, MAX_EEPROM_CAPACITY);
+//  NOTE: EEPROM reset:
+//  EEPROM.write(0, 'f');
+//  EEPROM.write(1, 'o');
+//  EEPROM.write(2, '0');
 
+  // DataController::writeDataToEEPROM(keysDB, 2, MAX_EEPROM_CAPACITY);
   keysDatabase = DataController::readDataFromEEPROM(&numberOfKeys);
-  // for(int i = 0; i < 4; i++){
-  //   Serial.print("Slowo ");
-  //   Serial.print(i);
-  //   Serial.print(":");
-  //   Serial.println(keysDatabase[i]);
-  // }
-  
+
 
   if(numberOfKeys == 0){
-    Serial.println("Brak kluczy!");
+    Serial.println("No key in memory!");
+    Serial.println("The app gets frozen");
+    while(true){};
   }
 }
 
@@ -93,16 +70,10 @@ void setup() {
 void loop() {  
   // Choose a key:
   String usedPrivKey {keysDatabase[1]};   // TODO: Hard-code key index
-
-<<<<<<< HEAD
+  
   String txtKey{Converter::convBase32ToTxt(&usedPrivKey)};
   uint8_t * hmacKey{Converter::convStrToNumArr(&txtKey)};
   TOTP totp = TOTP(hmacKey, 20);         // TODO: Hard-code max size of key (use `.length()` on key from array)
-=======
-  String txtKey {Converter::convBase32ToTxt(&usedPrivKey)};
-  uint8_t* hmacKey {Converter::convStrToNumArr(&txtKey)};
-  TOTP totp = TOTP(hmacKey, 20);    // TODO: Hard-code size of key
->>>>>>> parent of 42dccc5 (Autoformat and add TODO notes about delete array and write data to EEPROM)
 
   char code[7];
 
@@ -128,7 +99,13 @@ void loop() {
   Serial.println("==============");
 
 
-  // Dynamic refresh (Always every 00' and 30' seconds)
+  //! Dynamic refresh (Always every 00' and 30' seconds)
   uint16_t restTime {(30 - (UTC % 30)) * 1000};
   delay(restTime);
+}
+
+void serialFlush(){
+  while(Serial.available() > 0) {
+    char t = Serial.read();
+  }
 }

--- a/u2f_arduino_key/u2f_arduino_key.ino
+++ b/u2f_arduino_key/u2f_arduino_key.ino
@@ -15,8 +15,9 @@
 
 // ******************************************************************
 // Configuration:
+<<<<<<< HEAD
 //TODO: Add description
-constexpr int8_t CONTROL_BTN_PIN {7};
+//constexpr int8_t CONTROL_BTN_PIN {7};
 //TODO: Add description
 constexpr int MAX_EEPROM_CAPACITY {30};
 /* The hour difference between the time zone set to RTC and the UTC time zone [in hours]:
@@ -27,16 +28,29 @@ constexpr int8_t TIME_ZONE_OFFSET {2};
  * 1698601110 - 1698601115 = -5 [s]
  * */
 constexpr int8_t RTC_OFFSET {-5};
+=======
+// constexpr uint8_t KEY_SIZE {30};       //TODO:  Moved to dataConverter.h
+
+  /* The hour difference between the time zone set to RTC and the UTC time zone [in hours]:
+   * CET(summer_time) - UTC = 2 [h]
+   * */
+  constexpr int8_t TIME_ZONE_OFFSET {2};
+  /* Time difference between the RTC module time and the real time [in seconds]:
+   * 1698601110 - 1698601115 = -5 [s]
+   * */
+  constexpr int8_t RTC_OFFSET {-5};
+  constexpr int MAX_EEPROM_CAPACITY {30};
+>>>>>>> parent of 42dccc5 (Autoformat and add TODO notes about delete array and write data to EEPROM)
 
 
 // ******************************************************************
 // Example database with Base32 format keys:
-String keysDB[4]{"github", "JV4VG2LNOBWGKU3FMNZGK5CUPB2EWZLZ",   // "MySimpleSecretTxtKey"
-                 "text", "IFBEGRBRGIZQ===="};                    // "ABCD123"
+String keysDB[4] {"github", "JV4VG2LNOBWGKU3FMNZGK5CUPB2EWZLZ",   // "MySimpleSecretTxtKey"
+                  "text", "IFBEGRBRGIZQ===="};                    // "ABCD123"
 
 
-int numberOfKeys{};
-String *keysDatabase{};
+int numberOfKeys {};
+String *keysDatabase {};
 
 
 // ******************************************************************
@@ -58,7 +72,8 @@ void setup() {
   Serial.begin(9600);
   Wire.begin();
 
-  // DataController::writeDataToEEPROM(keysDB, 2, MAX_EEPROM_CAPACITY);   // First import data
+  // EEPROM.write(0, 0);
+  // DataController::writeDataToEEPROM(keysDB, 2, MAX_EEPROM_CAPACITY);
 
   keysDatabase = DataController::readDataFromEEPROM(&numberOfKeys);
   // for(int i = 0; i < 4; i++){
@@ -67,36 +82,42 @@ void setup() {
   //   Serial.print(":");
   //   Serial.println(keysDatabase[i]);
   // }
+  
 
-
-  if (numberOfKeys == 0) {
+  if(numberOfKeys == 0){
     Serial.println("Brak kluczy!");
   }
 }
 
 
-void loop() {
+void loop() {  
   // Choose a key:
-  String usedPrivKey{keysDatabase[1]};   // TODO: Hard-code key index
+  String usedPrivKey {keysDatabase[1]};   // TODO: Hard-code key index
 
+<<<<<<< HEAD
   String txtKey{Converter::convBase32ToTxt(&usedPrivKey)};
   uint8_t * hmacKey{Converter::convStrToNumArr(&txtKey)};
   TOTP totp = TOTP(hmacKey, 20);         // TODO: Hard-code max size of key (use `.length()` on key from array)
+=======
+  String txtKey {Converter::convBase32ToTxt(&usedPrivKey)};
+  uint8_t* hmacKey {Converter::convStrToNumArr(&txtKey)};
+  TOTP totp = TOTP(hmacKey, 20);    // TODO: Hard-code size of key
+>>>>>>> parent of 42dccc5 (Autoformat and add TODO notes about delete array and write data to EEPROM)
 
   char code[7];
 
 
   // Get currently time from RTC module:
-  DateTime now{myRTC.now()};           // Get current time
-  long UnixTimeStep{now.unixtime()};   // Replacement in Unix TimeStamp
+  DateTime now {myRTC.now()};           // Get current time
+  long UnixTimeStep {now.unixtime()};   // Replacement in Unix TimeStamp
   //   UTC = (local_time - TIME_ZONE_OFFSET - RTC_OFFSET)
-  long UTC{UnixTimeStep - (TIME_ZONE_OFFSET * 60 * 60) - RTC_OFFSET};
+  long UTC {UnixTimeStep - (TIME_ZONE_OFFSET*60*60) - RTC_OFFSET};
 
 //  Serial.print("TIME: ");
 //  Serial.println(UTC);
 
 
-  char *newCode{totp.getCode(UTC)};  // Generate new token
+  char* newCode {totp.getCode(UTC)};  // Generate new token
 
   // Print token
   if (strcmp(code, newCode) != 0) {
@@ -108,9 +129,6 @@ void loop() {
 
 
   // Dynamic refresh (Always every 00' and 30' seconds)
-  uint16_t restTime{(30 - (UTC % 30)) * 1000};
+  uint16_t restTime {(30 - (UTC % 30)) * 1000};
   delay(restTime);
 }
-
-// delete[] keysDatabase;                                                               // TODO: To ADD
-// DataController::writeDataToEEPROM(keysDatabase, numberOfKeys, MAX_EEPROM_CAPACITY);  // TODO: To ADD (after pressing button or after add new key)

--- a/u2f_arduino_key/u2f_arduino_key.ino
+++ b/u2f_arduino_key/u2f_arduino_key.ino
@@ -14,27 +14,25 @@
 
 
 // ******************************************************************
-// Configuration:
+//! Configuration:
 /*! The hour difference between the time zone set to RTC and the UTC time zone [in hours]:
  * CET(summer_time) - UTC = 2 [h]
  * */
 constexpr int8_t TIME_ZONE_OFFSET {2};
+
 /*! Time difference between the RTC module time and the real time [in seconds]:
  * 1698601110 - 1698601115 = -5 [s]
  * */
 constexpr int8_t RTC_OFFSET {-5};
-
-
 // ******************************************************************
 // Example database with Base32 format keys:
 String keysDB[4] {"github", "JV4VG2LNOBWGKU3FMNZGK5CUPB2EWZLZ",   // "MySimpleSecretTxtKey"
                   "text", "IFBEGRBRGIZQ===="};                    // "ABCD123"
 
-
+// ******************************************************************
+//! RAM memmory:
 int numberOfKeys {0};
 String *keysDatabase {};
-
-
 // ******************************************************************
 /*! Using the DS3231 RTC module requires its prior configuration and setting of the current time
  * from which the RTC will constantly count up. For this, you can use the DS3231.h library and

--- a/u2f_arduino_key/u2f_arduino_key.ino
+++ b/u2f_arduino_key/u2f_arduino_key.ino
@@ -15,21 +15,18 @@
 
 // ******************************************************************
 // Configuration:
-// constexpr uint8_t KEY_SIZE {30};       //TODO:  Moved to dataConverter.h
-
+//TODO: Add description
+constexpr int8_t CONTROL_BTN_PIN {7};
+//TODO: Add description
+constexpr int MAX_EEPROM_CAPACITY {30};
 /* The hour difference between the time zone set to RTC and the UTC time zone [in hours]:
  * CET(summer_time) - UTC = 2 [h]
  * */
-constexpr int8_t
-TIME_ZONE_OFFSET {
-2};
+constexpr int8_t TIME_ZONE_OFFSET {2};
 /* Time difference between the RTC module time and the real time [in seconds]:
  * 1698601110 - 1698601115 = -5 [s]
  * */
-constexpr int8_t
-RTC_OFFSET {
--5};
-constexpr int MAX_EEPROM_CAPACITY{30};
+constexpr int8_t RTC_OFFSET {-5};
 
 
 // ******************************************************************
@@ -48,6 +45,13 @@ String *keysDatabase{};
  * the DS3231_set example.
  * */
 RTClib myRTC;
+
+enum class OPTIONS {POWEROFF = 0,
+                    GENERATE,
+                    ADDNEW};
+
+void generateToken();
+void addNewKey();
 
 
 void setup() {
@@ -77,7 +81,7 @@ void loop() {
 
   String txtKey{Converter::convBase32ToTxt(&usedPrivKey)};
   uint8_t * hmacKey{Converter::convStrToNumArr(&txtKey)};
-  TOTP totp = TOTP(hmacKey, 20);          // TODO: Hard-code max size of key
+  TOTP totp = TOTP(hmacKey, 20);         // TODO: Hard-code max size of key (use `.length()` on key from array)
 
   char code[7];
 


### PR DESCRIPTION
## Operation control
The division was initially intended to divide main `loop()` operations into several separate functions.
However, this option was not added due to an error in the operation of the `switch` statement.

### News:
* Adding const variable for determining the pin number of the action button and the maximum number of keys that can be saved in Arduino's EEPROM memory,
* Defining an `enum` type, with possible operations,
* Adding a **system to add and check a special prefix** in the EEPROM memory.
If there isn't the prefix in the memory, the user can overwrite the current memory and enable work with the device or end the work,
* Added a function to clean the `UART serial` from garbage.

### Changes:
* Autoformat code and add new comments (including documentation comments),
* Adding a new folder to `.gitignore` file which contains private materials needed in the creative process.

---
Close: