### PR TITLE
Convert Base32 to byte format and fix any problems

### DIFF
--- a/u2f_arduino_key/src/dataController.cpp
+++ b/u2f_arduino_key/src/dataController.cpp
@@ -8,6 +8,8 @@ static void DataController::writeDataToEEPROM(String *keys, const int numberOfKe
   int addresIndex {0};
 
   addPrefixToEEPROM(&addresIndex);
+//  Serial.print("All keys: ");
+//  Serial.println(numberOfKeys);
   writeIntToEEPROM(&addresIndex, numberOfKeys);
   writeIntToEEPROM(&addresIndex, MAX_SIZE);
 
@@ -16,8 +18,12 @@ static void DataController::writeDataToEEPROM(String *keys, const int numberOfKe
   } else {
 //    Serial.println("DEBUG: Saving is in processing");
     for(int i = 0; i < (numberOfKeys*2); i++) {
-      uint8_t txtSize = keys[i].length() + 1;
+      uint8_t txtSize = keys[i].length();
+//      Serial.print("Save: ");
+//      Serial.println(txtSize);
       writeIntToEEPROM(&addresIndex, txtSize);
+//      Serial.print("Save: ");
+//      Serial.println(keys[i]);
       writeStringToEEPROM(&addresIndex, keys[i]);
     }
   }
@@ -33,14 +39,20 @@ static String* DataController::readDataFromEEPROM(int *numberOfKeys) {
 
     uint8_t keysNumber = readIntFromEEPROM(&addresIndex);
     (*numberOfKeys) = keysNumber;
+//    Serial.print("All keys: ");
+//    Serial.println(keysNumber);
     uint8_t maxEEPROMSize = readIntFromEEPROM(addresIndex++);
 //    addresIndex++;
 
     static String *keys = new String[keysNumber*2];
 
-    for(int i = 0; i < keysNumber*2; i++) {
+    for(int i = 0; i < (keysNumber*2); i++) {
       uint8_t txtSize = readIntFromEEPROM(&addresIndex);
+//      Serial.print("Read: ");
+//      Serial.println(txtSize);
       keys[i] = readStringFromEEPROM(&addresIndex, txtSize);
+//      Serial.print("Read: ");
+//      Serial.println(keys[i]);
     }
 
 //    Serial.println("DEBUG: Reading complited!");
@@ -124,7 +136,7 @@ static int DataController::readIntFromEEPROM(int *addrOffset) {
 }
 
 
-static void DataController::writeStringToEEPROM(int *addrOffset, const String &txt, bool nullChar) {
+static void DataController::writeStringToEEPROM(int *addrOffset, const String txt, bool nullChar) {
   uint8_t size = txt.length();
 
   for (int i = 0; i < size; i++) {
@@ -140,6 +152,8 @@ static void DataController::writeStringToEEPROM(int *addrOffset, const String &t
 
 static String DataController::readStringFromEEPROM(int *addrOffset, int size, bool nullChar) {
   String data {};
+//  Serial.print("ADres: ");
+//  Serial.println(*addrOffset);
 
   for (int i = 0; i < size; i++) {
     data += static_cast<char>(EEPROM.read((*addrOffset) + i));
@@ -150,6 +164,7 @@ static String DataController::readStringFromEEPROM(int *addrOffset, int size, bo
     data += '\0';
     (*addrOffset)++;
   }
-
+//  Serial.print("Size2: ");
+//  Serial.println(data.length());
   return data;
 }

--- a/u2f_arduino_key/src/dataController.cpp
+++ b/u2f_arduino_key/src/dataController.cpp
@@ -139,20 +139,17 @@ static void DataController::writeStringToEEPROM(int *addrOffset, const String &t
 }
 
 static String DataController::readStringFromEEPROM(int *addrOffset, int size, bool nullChar) {
-//  char data[size + 1];
-  char *data = new char[size];
+  String data {};
 
   for (int i = 0; i < size; i++) {
-    data[i] = EEPROM.read((*addrOffset) + i);
+    data += static_cast<char>(EEPROM.read((*addrOffset) + i));
   }
   (*addrOffset) += size;
 
   if(nullChar) {
-    data[size] = '\0';
+    data += '\0';
     (*addrOffset)++;
   }
 
-  String txt = data;
-  delete[] data;
-  return txt;
+  return data;
 }

--- a/u2f_arduino_key/src/dataController.cpp
+++ b/u2f_arduino_key/src/dataController.cpp
@@ -8,8 +8,6 @@ static void DataController::writeDataToEEPROM(String *keys, const int numberOfKe
   int addresIndex {0};
 
   addPrefixToEEPROM(&addresIndex);
-//  Serial.print("All keys: ");
-//  Serial.println(numberOfKeys);
   writeIntToEEPROM(&addresIndex, numberOfKeys);
   writeIntToEEPROM(&addresIndex, MAX_SIZE);
 
@@ -19,11 +17,7 @@ static void DataController::writeDataToEEPROM(String *keys, const int numberOfKe
 //    Serial.println("DEBUG: Saving is in processing");
     for(int i = 0; i < (numberOfKeys*2); i++) {
       uint8_t txtSize = keys[i].length();
-//      Serial.print("Save: ");
-//      Serial.println(txtSize);
       writeIntToEEPROM(&addresIndex, txtSize);
-//      Serial.print("Save: ");
-//      Serial.println(keys[i]);
       writeStringToEEPROM(&addresIndex, keys[i]);
     }
   }
@@ -39,20 +33,13 @@ static String* DataController::readDataFromEEPROM(int *numberOfKeys) {
 
     uint8_t keysNumber = readIntFromEEPROM(&addresIndex);
     (*numberOfKeys) = keysNumber;
-//    Serial.print("All keys: ");
-//    Serial.println(keysNumber);
     uint8_t maxEEPROMSize = readIntFromEEPROM(addresIndex++);
-//    addresIndex++;
 
     static String *keys = new String[keysNumber*2];
 
     for(int i = 0; i < (keysNumber*2); i++) {
       uint8_t txtSize = readIntFromEEPROM(&addresIndex);
-//      Serial.print("Read: ");
-//      Serial.println(txtSize);
       keys[i] = readStringFromEEPROM(&addresIndex, txtSize);
-//      Serial.print("Read: ");
-//      Serial.println(keys[i]);
     }
 
 //    Serial.println("DEBUG: Reading complited!");
@@ -152,8 +139,6 @@ static void DataController::writeStringToEEPROM(int *addrOffset, const String tx
 
 static String DataController::readStringFromEEPROM(int *addrOffset, int size, bool nullChar) {
   String data {};
-//  Serial.print("ADres: ");
-//  Serial.println(*addrOffset);
 
   for (int i = 0; i < size; i++) {
     data += static_cast<char>(EEPROM.read((*addrOffset) + i));
@@ -164,7 +149,6 @@ static String DataController::readStringFromEEPROM(int *addrOffset, int size, bo
     data += '\0';
     (*addrOffset)++;
   }
-//  Serial.print("Size2: ");
-//  Serial.println(data.length());
+
   return data;
 }

--- a/u2f_arduino_key/src/dataController.h
+++ b/u2f_arduino_key/src/dataController.h
@@ -39,7 +39,7 @@ private:
 
   static int readIntFromEEPROM(int *);
 
-  static void writeStringToEEPROM(int *, const String &, bool nullChar = true);
+  static void writeStringToEEPROM(int *, const String, bool nullChar = false);
 
   static String readStringFromEEPROM(int *, int, bool nullChar = false);
 };

--- a/u2f_arduino_key/src/dataConverter.cpp
+++ b/u2f_arduino_key/src/dataConverter.cpp
@@ -36,3 +36,14 @@ static byte* Converter::stringToByteArr(String txt) {
 
   return stringInByte;
 }
+
+static String Converter::byteArrToString(byte *byteArr, uint16_t size) {
+  String newtext {};
+
+  for(int i = 0; i < size; i++){
+    char c {static_cast<char>(byteArr[i])};
+    newtext += c;
+  }
+
+  return newtext;
+}

--- a/u2f_arduino_key/src/dataConverter.cpp
+++ b/u2f_arduino_key/src/dataConverter.cpp
@@ -28,3 +28,11 @@ uint8_t* Converter::convStrToNumArr(String* txt) {
 
   return NumArr;
 }
+
+
+static byte* Converter::stringToByteArr(String txt) {
+  static byte *stringInByte = new byte[txt.length()+1];
+  txt.getBytes(stringInByte, txt.length()+1);
+
+  return stringInByte;
+}

--- a/u2f_arduino_key/src/dataConverter.h
+++ b/u2f_arduino_key/src/dataConverter.h
@@ -23,6 +23,9 @@ public:
    * */
   static uint8_t* convStrToNumArr(String*);
 
+//!  Function convert String to byte array
+  static byte* stringToByteArr(String);
+
 };
 
 #endif //U2F_ARDUINO_KEY_DATACONVERTER_H

--- a/u2f_arduino_key/src/dataConverter.h
+++ b/u2f_arduino_key/src/dataConverter.h
@@ -23,8 +23,11 @@ public:
    * */
   static uint8_t* convStrToNumArr(String*);
 
-//!  Function convert String to byte array
+//!  TODO: Function convert String to byte array
   static byte* stringToByteArr(String);
+
+//!  TODO: Function convert byte array to String
+  static String byteArrToString(byte *byteArr, uint16_t size);
 
 };
 

--- a/u2f_arduino_key/u2f_arduino_key.ino
+++ b/u2f_arduino_key/u2f_arduino_key.ino
@@ -34,8 +34,9 @@ constexpr int8_t TIME_ZONE_OFFSET {2};
 constexpr int8_t RTC_OFFSET {-5};
 // ******************************************************************
 // Example database with Base32 format keys:
-String keysDB[4]{"text", "JV4VG2LNOBWGKU3FMNZGK5CUPB2EWZLZ",      // "MySimpleSecretTxtKey"
-                 "github", "AWS4R4HCB5Z54SR2"};                   // NONE
+String keysDB[4]{"google", "N7QBAAAJUCPUP37V",
+                 "github", "AWS4R4HCB5Z54SR2"};
+//               "fb",     "JBSWY3DPEHPK3PXP"         // Example
 
 // ******************************************************************
 //! RAM memmory:
@@ -61,7 +62,7 @@ void setup() {
 //  EEPROM.write(1, 'o');
 //  EEPROM.write(2, 'o');
 
-//  DataController::writeDataToEEPROM(keysDB, 2);
+  DataController::writeDataToEEPROM(keysDB, 2);
   keysDatabase = DataController::readDataFromEEPROM(&numberOfKeys);
 
 
@@ -70,7 +71,7 @@ void setup() {
     Serial.println("The app gets frozen");
     while (true) {};
   } else {
-    activeKeyIndex = {5};
+    activeKeyIndex = {1};
   }
 }
 
@@ -80,15 +81,17 @@ void loop() {
   int option = Controller::btnDetector(CONTROL_BTN_PIN, BTN_LOOP_COOLDOWN, WAIT_FOR_ANOTHER_CLICK, HOW_LONG_PRESS_BTN);
 
   if(option == Controller::GENERATE_TOKEN) {
-    for(int i = 0; i < numberOfKeys*2 ; i++) {
-      Serial.println(keysDatabase[i]);
-    }
-    Serial.print("Active: ");
-    Serial.println(activeKeyIndex);
-
+//    for(int i = 0; i < numberOfKeys*2 ; i++) {
+//      Serial.println(keysDatabase[i]);
+//      Serial.print("Size: ");
+//      Serial.println(keysDatabase[i].length());
+//    }
+//    Serial.print("Active: ");
+//    Serial.println(activeKeyIndex);
+//
     String privKey = {keysDatabase[activeKeyIndex]};
-    Serial.print("Key: ");
-    Serial.println(privKey);
+//    Serial.print("Key: ");
+//    Serial.println(privKey);
 
 //!    Convert StringToChar:
     uint8_t privKeySize = privKey.length();
@@ -110,6 +113,12 @@ void loop() {
       if(i >= cutAfter && codeInByte[i] == 0) break;
       hmacKey[i] = codeInByte[i];
     }
+//
+//    for(int i = 0; i < maxout; i++){
+//      Serial.print(hmacKey[i]);
+//      Serial.print(", ");
+//    }
+//    Serial.println("");
 
 //!    Create TOTP object:
     TOTP totp = TOTP(hmacKey, maxout);
@@ -193,6 +202,11 @@ void loop() {
     keysDatabase = newKeysDB;
     newKeysDB = {nullptr};
 
+//    Serial.println("Dane: ");
+//    for(int i = 0; i < (numberOfKeys*2)-2; i++){
+//      Serial.println(keysDatabase[i]);
+//    }
+    delay(10);
 //!    Get new name and new key:
     String newKeyName, newKeyBs32 {};
 
@@ -204,12 +218,11 @@ void loop() {
       newKeyName = Serial.readStringUntil('\n');
       newKeyName.trim();
     }
-    Serial.println("");
-    Serial.print("Name: ");
-    Serial.println(newKeyName);
+//    Serial.println("");
+//    Serial.print("Name: ");
+//    Serial.println(newKeyName);
 
-
-    Serial.print("Write new key (in Base32): ");
+//    Serial.print("Write new key in Base32: ");
     Controller::serialFlushCleaner();
     while (Serial.available() == 0) {}
     delay(2);
@@ -217,15 +230,20 @@ void loop() {
       newKeyBs32 = Serial.readStringUntil('\n');
       newKeyBs32.trim();
     }
-    Serial.println("");
+//    Serial.println("");
+//    Serial.print("Key: ");
+//    Serial.println(newKeyBs32);
 
 //    Save new data in DB:
     keysDatabase[(numberOfKeys*2)-2] = {newKeyName};
     keysDatabase[(numberOfKeys*2)-1] = {newKeyBs32};
 
-    
+    for(int i = 0; i < (numberOfKeys*2); i++){
+      Serial.println(keysDatabase[i]);
+    }
+
 //!    Save new array in EEPROM:
-    Serial.println("Writing new key in memory...");
+//    Serial.println("Writing new key in memory...");
     DataController::writeDataToEEPROM(keysDatabase, numberOfKeys);
     Serial.println("Done");
   }

--- a/u2f_arduino_key/u2f_arduino_key.ino
+++ b/u2f_arduino_key/u2f_arduino_key.ino
@@ -40,7 +40,7 @@ String keysDB[4]{"text", "JV4VG2LNOBWGKU3FMNZGK5CUPB2EWZLZ",      // "MySimpleSe
 // ******************************************************************
 //! RAM memmory:
 int numberOfKeys{0};
-int activeKeyIndex{1};    // TODO: Change to 0
+int activeKeyIndex{0};
 String *keysDatabase{};
 // ******************************************************************
 /*! Using the DS3231 RTC module requires its prior configuration and setting of the current time
@@ -69,6 +69,8 @@ void setup() {
     Serial.println("No key in memory!");
     Serial.println("The app gets frozen");
     while (true) {};
+  } else {
+    activeKeyIndex = {1};
   }
 }
 
@@ -122,7 +124,7 @@ void loop() {
     }
   }
   else if (option == Controller::CHOOSE_KEY) {
-    Serial.print("Give key name: ");
+    Serial.print("Enter a key name: ");
 
     String name{};
     Controller::serialFlushCleaner();
@@ -136,21 +138,35 @@ void loop() {
 
     Serial.print("Name: ");
     Serial.println(name);
-    Serial.println(name.length());
 
+
+    int wantedNameSize = name.length();
+    wantedNameSize += 1;
+    char *wantedName = new char[wantedNameSize];
+    name.toCharArray(wantedName, wantedNameSize);
+
+    bool keyIsFound {false};
     for(int nameIndex = 0; nameIndex < (numberOfKeys*2); nameIndex+=2) {
       String nameFromArr = keysDatabase[nameIndex];
+      int currNameSize = nameFromArr.length();
+      currNameSize += 1;
+      char *currentName = new char[currNameSize];
+      nameFromArr.toCharArray(currentName, currNameSize);
 
-      Serial.print(nameFromArr);
-      Serial.print(" == ");
-      Serial.println(name);
-      if(nameFromArr.equals(name)) {
-        Serial.println("Jest!");
+      if(strcmp(currentName, wantedName) == 0) {
+        keyIsFound = {true};
+        activeKeyIndex = {nameIndex+1};
 
-        activeKeyIndex = nameIndex+1;
-        Serial.println(activeKeyIndex);
+        Serial.println("Key found");
         break;
       }
+
+      delete[] currentName;
+    }
+    delete[] wantedName;
+
+    if(!keyIsFound) {
+      Serial.println("This key does not exist in memory!");
     }
   }
   else if (option == Controller::ADD_NEW) {

--- a/u2f_arduino_key/u2f_arduino_key.ino
+++ b/u2f_arduino_key/u2f_arduino_key.ino
@@ -81,17 +81,11 @@ void loop() {
   int option = Controller::btnDetector(CONTROL_BTN_PIN, BTN_LOOP_COOLDOWN, WAIT_FOR_ANOTHER_CLICK, HOW_LONG_PRESS_BTN);
 
   if(option == Controller::GENERATE_TOKEN) {
-//    for(int i = 0; i < numberOfKeys*2 ; i++) {
-//      Serial.println(keysDatabase[i]);
-//      Serial.print("Size: ");
-//      Serial.println(keysDatabase[i].length());
-//    }
-//    Serial.print("Active: ");
-//    Serial.println(activeKeyIndex);
-//
+    Serial.print("Active: ");
+    Serial.println(keysDatabase[activeKeyIndex-1]);
+
+
     String privKey = {keysDatabase[activeKeyIndex]};
-//    Serial.print("Key: ");
-//    Serial.println(privKey);
 
 //!    Convert StringToChar:
     uint8_t privKeySize = privKey.length();
@@ -113,12 +107,6 @@ void loop() {
       if(i >= cutAfter && codeInByte[i] == 0) break;
       hmacKey[i] = codeInByte[i];
     }
-//
-//    for(int i = 0; i < maxout; i++){
-//      Serial.print(hmacKey[i]);
-//      Serial.print(", ");
-//    }
-//    Serial.println("");
 
 //!    Create TOTP object:
     TOTP totp = TOTP(hmacKey, maxout);
@@ -201,12 +189,8 @@ void loop() {
     delete[] keysDatabase;
     keysDatabase = newKeysDB;
     newKeysDB = {nullptr};
-
-//    Serial.println("Dane: ");
-//    for(int i = 0; i < (numberOfKeys*2)-2; i++){
-//      Serial.println(keysDatabase[i]);
-//    }
     delay(10);
+
 //!    Get new name and new key:
     String newKeyName, newKeyBs32 {};
 
@@ -218,7 +202,7 @@ void loop() {
       newKeyName = Serial.readStringUntil('\n');
       newKeyName.trim();
     }
-//    Serial.println("");
+    Serial.println("");
 //    Serial.print("Name: ");
 //    Serial.println(newKeyName);
 
@@ -230,17 +214,11 @@ void loop() {
       newKeyBs32 = Serial.readStringUntil('\n');
       newKeyBs32.trim();
     }
-//    Serial.println("");
-//    Serial.print("Key: ");
-//    Serial.println(newKeyBs32);
+    Serial.println("");
 
-//    Save new data in DB:
+//!    Save new data in DB:
     keysDatabase[(numberOfKeys*2)-2] = {newKeyName};
     keysDatabase[(numberOfKeys*2)-1] = {newKeyBs32};
-
-    for(int i = 0; i < (numberOfKeys*2); i++){
-      Serial.println(keysDatabase[i]);
-    }
 
 //!    Save new array in EEPROM:
 //    Serial.println("Writing new key in memory...");

--- a/u2f_arduino_key/u2f_arduino_key.ino
+++ b/u2f_arduino_key/u2f_arduino_key.ino
@@ -203,10 +203,10 @@ void loop() {
       newKeyName.trim();
     }
     Serial.println("");
-//    Serial.print("Name: ");
-//    Serial.println(newKeyName);
+    Serial.print("Name: ");
+    Serial.println(newKeyName);
 
-//    Serial.print("Write new key in Base32: ");
+    Serial.print("Write new key in Base32: ");
     Controller::serialFlushCleaner();
     while (Serial.available() == 0) {}
     delay(2);
@@ -215,6 +215,8 @@ void loop() {
       newKeyBs32.trim();
     }
     Serial.println("");
+    Serial.print("New key: ");
+    Serial.println(newKeyBs32);
 
 //!    Save new data in DB:
     keysDatabase[(numberOfKeys*2)-2] = {newKeyName};

--- a/u2f_arduino_key/u2f_arduino_key.ino
+++ b/u2f_arduino_key/u2f_arduino_key.ino
@@ -33,9 +33,9 @@ constexpr int8_t TIME_ZONE_OFFSET {2};
  * */
 constexpr int8_t RTC_OFFSET {-5};
 // ******************************************************************
-// Example database with Base32 format keys:
-String keysDB[4]{"google", "N7QBAAAJUCPUP37V",
-                 "github", "AWS4R4HCB5Z54SR2"};
+// NOTE: Example database with Base32 format keys:
+//String keysDB[4]{"google", "N7QBAAAJUCPUP37V",
+//                 "github", "AWS4R4HCB5Z54SR2"};
 //               "fb",     "JBSWY3DPEHPK3PXP"         // Example
 
 // ******************************************************************
@@ -62,7 +62,7 @@ void setup() {
 //  EEPROM.write(1, 'o');
 //  EEPROM.write(2, 'o');
 
-  DataController::writeDataToEEPROM(keysDB, 2);
+//  DataController::writeDataToEEPROM(keysDB, 2);
   keysDatabase = DataController::readDataFromEEPROM(&numberOfKeys);
 
 


### PR DESCRIPTION
## Convert Base32 to byte format and fix any problems
The changes mainly concerned the conversion of `Base32` to `byte` array and fixing all errors.

### News:
* Adding function converts String text into bytes array: `stringToByteArr`,
* Adding function converts bytes array into String text: `byteArrToString`.

### Changes:
* The `readStringFromEEPROM` function now gets the text as a `String` from the EEPROM memory (not `*char`),
* The program's database (RAM) stores only key names and keys in the `Base32` format,
* From now on, **the function converts the key in `Base32` format into bytes and stored them in `int` array**,
* Comparing the searched name with the key name is done by converting names (in `String`) into `char` array,
* Messages and comments have been edited.

### Fix:
* After conversion (Base32 to byte), garbage bytes are created.
They are removed in the process: 
  * Calculate: _floor(`KeyBs32`.length()*5/8)_,
  * Resetting all numbers after zero that are in a position above the calculated value.

---
 Fix #20 